### PR TITLE
State mach: JSONata transform replaces $merge; error consistency; SourceType

### DIFF
--- a/README.md
+++ b/README.md
@@ -244,20 +244,15 @@ to document and explain your state machine. Here is my advice:
     - Add a comment if a term cannot be used in searches. Search features don't
       allow, or don't do a good job with: symbols; the definite article "the";
       other short "stop-words"; and words with two or more popular meanings.
-      For example, this JSONata expression:
+      For example, without the comment, this JSONata expression:
 
       ```jsonata
-      $states.input ~> | $ | {}, ['Error', 'Cause'] |
+      $states.input ~> |$|{}, ['Error', 'Cause']| /* https://docs.jsonata.org/other-operators#-------transform */
       ```
 
-      gives no clue about what to search for. It is impossible to search for
-      `$`, `{}`, or `|`, and probably for `~>` too. So, I add an in-line
-      comment explaining what the expression accomplishes, and I provide a
-      link to the description of the cryptic operator:
-
-      ```jsonata
-      /* Delete any past error; https://docs.jsonata.org/other-operators#-------transform */
-      ```
+      would give no clue about what to search for. It is impossible to search
+      for `|` or `$`, and probably for `~>` too. I would make sure at least one
+      occurrence received a comment.
 
  6. Although a JSON object's keys form a set, and sets are unordered, changing
     the order of the keys in a state machine's JSON definition code after the

--- a/step_stay_stopped_aws_rds_aurora.asl.json
+++ b/step_stay_stopped_aws_rds_aurora.asl.json
@@ -7,28 +7,26 @@
     "AssignConstantsAndExtractDbIdentifierFromEvent": {
       "Type": "Pass",
       "Assign": {
-        "Constant": "{% {\n  'StepFnTaskTimeoutSeconds': ${StepFnTaskTimeoutSeconds},\n  'DoNotFollowUntilStopped': 'false' = '${FollowUntilStopped}' /* CloudFormation supplies a string! */,\n  'StepFnWaitSeconds': ${StepFnWaitSeconds},\n  'StepFnTimeoutMilliseconds': ${StepFnTimeoutSeconds} * 1000\n} %}"
+        "Constant": "{% {\n  'StepFnTaskTimeoutSeconds': ${StepFnTaskTimeoutSeconds},\n  'DoNotFollowUntilStopped': $not(${FollowUntilStopped}),\n  'StepFnWaitSeconds': ${StepFnWaitSeconds},\n  'StepFnTimeoutMilliseconds': ${StepFnTimeoutSeconds} * 1000\n} %}"
       },
-      "Comment": "Process JSON state machine definition with CloudFormation Fn::Sub to resolve constants",
-      "Output": "{% {\n  'Event': $states.input,\n  'Date': $states.input.detail.Date,\n  'SourceIdentifier': $states.input.detail.SourceIdentifier,\n  'SourceTypeWord': $split($states.input.detail.SourceType,'_')[-1]\n  /* Last word of 'CLUSTER' (Aurora) or 'DB_INSTANCE' (RDS) */\n} %}",
+      "Comment": "Process JSON state machine definition with CloudFormation Fn::Sub to resolve parameters, which are substituted as unquoted strings",
+      "Output": "{% {\n  'Event': $states.input,\n  'Date': $states.input.detail.Date,\n  'SourceIdentifier': $states.input.detail.SourceIdentifier,\n  'SourceType': $states.input.detail.SourceType\n} %}",
       "Next": "IfEventNotExpiredChooseDbClusterOrInstance"
     },
     "IfEventNotExpiredChooseDbClusterOrInstance": {
       "Type": "Choice",
       "Choices": [
         {
-          "Condition": "{% $toMillis($states.input.Date) < ( $millis() - $Constant.StepFnTimeoutMilliseconds ) %}",
-          "Output": "{% $merge([\n  $states.input,\n  {'Error': 'EventExpired'}\n]) %}",
+          "Condition": "{% $toMillis($states.input.Date) < ($millis() - $Constant.StepFnTimeoutMilliseconds) %}",
+          "Output": "{% $states.input ~> |$|{'Error': $states.context.State.Name & '.' & 'EventExpired'}| /* https://docs.jsonata.org/other-operators#-------transform */ %}",
           "Next": "Fail"
         },
         {
-          "Condition": "{% 'CLUSTER' = $states.input.SourceTypeWord %}",
-          "Output": "{% \n  $states.input ~> | $ | {}, ['Error', 'Cause'] |\n  /* Delete any past error; https://docs.jsonata.org/other-operators#-------transform */\n %}",
+          "Condition": "{% 'CLUSTER' = $states.input.SourceType %}",
           "Next": "StopDBCluster"
         },
         {
-          "Condition": "{% 'INSTANCE' = $states.input.SourceTypeWord %}",
-          "Output": "{% \n  $states.input ~> | $ | {}, ['Error', 'Cause'] |\n  /* Delete any past error; https://docs.jsonata.org/other-operators#-------transform */\n %}",
+          "Condition": "{% 'DB_INSTANCE' = $states.input.SourceType %}",
           "Next": "StopDBInstance"
         }
       ]
@@ -36,16 +34,14 @@
     "StopDBCluster": {
       "Type": "Task",
       "Resource": "arn:aws:states:::aws-sdk:rds:stopDBCluster",
-      "Arguments": {
-        "DbClusterIdentifier": "{% $states.input.SourceIdentifier %}"
-      },
+      "Arguments": "{% {'DbClusterIdentifier': $states.input.SourceIdentifier} %}",
       "TimeoutSeconds": "{% $Constant.StepFnTaskTimeoutSeconds %}",
       "Catch": [
         {
           "ErrorEquals": [
             "Rds.InvalidDbClusterStateException"
           ],
-          "Output": "{% (\n  $DbClusterStatusRegExpMatch := $match($states.errorOutput.Cause, /^DbCluster [^ ]+ is in (.+) state/, 1);\n  $merge([\n    $states.input,\n    $DbClusterStatusRegExpMatch\n    ?\n    {'DbStatus': $lowercase($DbClusterStatusRegExpMatch.groups[0])}\n    :\n    {'DbStatus': '', 'Error': 'StopDBCluster|CannotParseException', 'Cause': $string($states.errorOutput.Cause)}\n  ])\n) %}",
+          "Output": "{% \n  $states.input\n  ~> |$|{'DbStatus': $lowercase($match($states.errorOutput.Cause, /^DbCluster [^ ]+ is in (.+) state/, 1).groups[0])}|\n  ~> |$|$.DbStatus ? {} : $states.errorOutput|\n  ~> |$|$.DbStatus ? {} : {'DbStatus': '', 'Error': $states.context.State.Name & '.' & $.Error & '.CannotParseException'}|\n %}",
           "Next": "DbStatus"
         },
         {
@@ -53,7 +49,7 @@
             "States.ALL"
           ],
           "Comment": "Includes Rds.InvalidDbInstanceStateException, which occurs until each cluster member becomes available",
-          "Output": "{% $merge([\n  $states.input,\n  {'Error': 'StopDBCluster|' & $states.errorOutput.Error, 'Cause': $string($states.errorOutput.Cause)}\n]) %}",
+          "Output": "{% $states.input ~> |$|$states.errorOutput| ~> |$|{'Error': $states.context.State.Name & '.' & $.Error}| %}",
           "Next": "Wait"
         }
       ],
@@ -63,30 +59,29 @@
     "StopDBInstance": {
       "Type": "Task",
       "Resource": "arn:aws:states:::aws-sdk:rds:stopDBInstance",
-      "Arguments": {
-        "DbInstanceIdentifier": "{% $states.input.SourceIdentifier %}"
-      },
+      "Arguments": "{% {'DbInstanceIdentifier': $states.input.SourceIdentifier} %}",
       "TimeoutSeconds": "{% $Constant.StepFnTaskTimeoutSeconds %}",
       "Catch": [
         {
           "ErrorEquals": [
             "Rds.InvalidDbInstanceStateException"
           ],
-          "Output": "{% $merge([\n  $states.input,\n  {'Error': 'StopDBInstance|' & $states.errorOutput.Error, 'Cause': $string($states.errorOutput.Cause)}\n]) %}",
+          "Output": "{% $states.input ~> |$|$states.errorOutput| ~> |$|{'Error': $states.context.State.Name & '.' & $.Error}| %}",
           "Next": "DescribeDBInstances"
         },
         {
           "ErrorEquals": [
             "Rds.RdsException"
           ],
-          "Output": "{% $merge([\n  $states.input,\n  {'Error': 'StopDBInstance|' & $states.errorOutput.Error, 'Cause': $string($states.errorOutput.Cause)}\n]) %}",
+          "Output": "{% $states.input ~> |$|$states.errorOutput| ~> |$|{'Error': $states.context.State.Name & '.' & $.Error}| %}",
+          "Comment": "Next state uses Cause key of stashed errorOutput",
           "Next": "AuroraDbInstanceNotEligibleForStopping?"
         },
         {
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Output": "{% $merge([\n  $states.input,\n  {'Error': 'StopDBInstance|' & $states.errorOutput.Error, 'Cause': $string($states.errorOutput.Cause)}\n]) %}",
+          "Output": "{% $states.input ~> |$|$states.errorOutput| ~> |$|{'Error': $states.context.State.Name & '.' & $.Error}| %}",
           "Next": "Wait"
         }
       ],
@@ -99,7 +94,7 @@
         {
           "Condition": "{% $contains($states.input.Cause, 'aurora') and $contains($states.input.Cause, 'not eligible for stopping') %}",
           "Comment": "Aurora: stop cluster, not instances. This InvalidParameterCombination occurs only in test mode. RDS-EVENT-0088 database instance non-forced start is indistinguishable for RDS (accepted) and Aurora (ignored in favor of RDS-EVENT-0151 for cluster).",
-          "Output": "{% $merge([\n  $states.input,\n  {'Info': 'StopAuroraClusterNotInstances'}\n]) %}",
+          "Output": "{% $states.input ~> |$|{'Info': 'StopAuroraClusterNotInstances'}| %}",
           "Next": "Succeed"
         }
       ],
@@ -108,20 +103,18 @@
     "DescribeDBInstances": {
       "Type": "Task",
       "Resource": "arn:aws:states:::aws-sdk:rds:describeDBInstances",
-      "Arguments": {
-        "DbInstanceIdentifier": "{% $states.input.SourceIdentifier %}"
-      },
+      "Arguments": "{% {'DbInstanceIdentifier': $states.input.SourceIdentifier} %}",
       "TimeoutSeconds": "{% $Constant.StepFnTaskTimeoutSeconds %}",
       "Catch": [
         {
           "ErrorEquals": [
             "States.ALL"
           ],
-          "Output": "{% $merge([\n  $states.input,\n{  'Error': 'DescribeDBInstances|' & $states.errorOutput.Error, 'Cause': $string($states.errorOutput.Cause)}\n]) %}",
+          "Output": "{% $states.input ~> |$|$states.errorOutput| ~> |$|{'Error': $states.context.State.Name & '.' & $.Error}| %}",
           "Next": "Wait"
         }
       ],
-      "Output": "{% (\n  $DbInstanceStatus := $states.result.DbInstances[0].DbInstanceStatus;\n  $merge([\n    $states.input,\n    $DbInstanceStatus\n    ?\n    {'DbStatus': $lowercase($DbInstanceStatus)}\n    :\n    {'DbStatus': '', 'Error': 'DescribeDBInstances|CannotParseResult', 'Cause': $string($states.result)}\n  ])\n) %}",
+      "Output": "{% \n  $states.input\n  ~> |$|{'DbStatus': $lowercase($states.result.DbInstances[0].DbInstanceStatus)}|\n  ~> |$|$.DbStatus ? {} : {'DbStatus': '', 'Error': $states.context.State.Name & '.CannotParseResult', 'Cause': $string($states.result)}|\n %}",
       "Next": "DbStatus"
     },
     "DbStatus": {
@@ -129,7 +122,7 @@
       "Choices": [
         {
           "Condition": "{% $states.input.DbStatus in ['inaccessible-encryption-credentials', 'cloning-failed', 'migration-failed', 'preparing-data-migration', 'failed', 'incompatible-restore', 'insufficient-capacity', 'restore-error', 'storage-full'] %}",
-          "Output": "{% $merge([\n  $states.input,\n  {'Error': 'CannotContinueInDbStatus'}\n]) %}",
+          "Output": "{% $states.input ~> |$|{'Error': $states.context.State.Name & '.CannotContinue'}| %}",
           "Next": "Fail"
         },
         {
@@ -152,6 +145,8 @@
     "Wait": {
       "Type": "Wait",
       "Seconds": "{% $Constant.StepFnWaitSeconds %}",
+      "Output": "{% $states.input ~> |$|{}, ['Error', 'Cause']| %}",
+      "Comment": "Deletes any past error",
       "Next": "IfEventNotExpiredChooseDbClusterOrInstance"
     },
     "Fail": {
@@ -159,7 +154,8 @@
     },
     "Succeed": {
       "Type": "Succeed",
-      "Output": "{% \n  $states.input ~> | $ | {}, ['Error', 'Cause', 'DbStatus'] |\n  /* Delete any past error, and possibly-stale status; https://docs.jsonata.org/other-operators#-------transform */\n %}"
+      "Output": "{% $states.input ~> |$|{}, ['DbStatus', 'Error', 'Cause']| %}",
+      "Comment": "Deletes possibly-stale status, and any past error"
     }
   }
 }

--- a/step_stay_stopped_aws_rds_aurora.yaml
+++ b/step_stay_stopped_aws_rds_aurora.yaml
@@ -697,28 +697,26 @@ Resources:
             "AssignConstantsAndExtractDbIdentifierFromEvent": {
               "Type": "Pass",
               "Assign": {
-                "Constant": "{% {\n  'StepFnTaskTimeoutSeconds': ${StepFnTaskTimeoutSeconds},\n  'DoNotFollowUntilStopped': 'false' = '${FollowUntilStopped}' /* CloudFormation supplies a string! */,\n  'StepFnWaitSeconds': ${StepFnWaitSeconds},\n  'StepFnTimeoutMilliseconds': ${StepFnTimeoutSeconds} * 1000\n} %}"
+                "Constant": "{% {\n  'StepFnTaskTimeoutSeconds': ${StepFnTaskTimeoutSeconds},\n  'DoNotFollowUntilStopped': $not(${FollowUntilStopped}),\n  'StepFnWaitSeconds': ${StepFnWaitSeconds},\n  'StepFnTimeoutMilliseconds': ${StepFnTimeoutSeconds} * 1000\n} %}"
               },
-              "Comment": "Process JSON state machine definition with CloudFormation Fn::Sub to resolve constants",
-              "Output": "{% {\n  'Event': $states.input,\n  'Date': $states.input.detail.Date,\n  'SourceIdentifier': $states.input.detail.SourceIdentifier,\n  'SourceTypeWord': $split($states.input.detail.SourceType,'_')[-1]\n  /* Last word of 'CLUSTER' (Aurora) or 'DB_INSTANCE' (RDS) */\n} %}",
+              "Comment": "Process JSON state machine definition with CloudFormation Fn::Sub to resolve parameters, which are substituted as unquoted strings",
+              "Output": "{% {\n  'Event': $states.input,\n  'Date': $states.input.detail.Date,\n  'SourceIdentifier': $states.input.detail.SourceIdentifier,\n  'SourceType': $states.input.detail.SourceType\n} %}",
               "Next": "IfEventNotExpiredChooseDbClusterOrInstance"
             },
             "IfEventNotExpiredChooseDbClusterOrInstance": {
               "Type": "Choice",
               "Choices": [
                 {
-                  "Condition": "{% $toMillis($states.input.Date) < ( $millis() - $Constant.StepFnTimeoutMilliseconds ) %}",
-                  "Output": "{% $merge([\n  $states.input,\n  {'Error': 'EventExpired'}\n]) %}",
+                  "Condition": "{% $toMillis($states.input.Date) < ($millis() - $Constant.StepFnTimeoutMilliseconds) %}",
+                  "Output": "{% $states.input ~> |$|{'Error': $states.context.State.Name & '.' & 'EventExpired'}| /* https://docs.jsonata.org/other-operators#-------transform */ %}",
                   "Next": "Fail"
                 },
                 {
-                  "Condition": "{% 'CLUSTER' = $states.input.SourceTypeWord %}",
-                  "Output": "{% \n  $states.input ~> | $ | {}, ['Error', 'Cause'] |\n  /* Delete any past error; https://docs.jsonata.org/other-operators#-------transform */\n %}",
+                  "Condition": "{% 'CLUSTER' = $states.input.SourceType %}",
                   "Next": "StopDBCluster"
                 },
                 {
-                  "Condition": "{% 'INSTANCE' = $states.input.SourceTypeWord %}",
-                  "Output": "{% \n  $states.input ~> | $ | {}, ['Error', 'Cause'] |\n  /* Delete any past error; https://docs.jsonata.org/other-operators#-------transform */\n %}",
+                  "Condition": "{% 'DB_INSTANCE' = $states.input.SourceType %}",
                   "Next": "StopDBInstance"
                 }
               ]
@@ -726,16 +724,14 @@ Resources:
             "StopDBCluster": {
               "Type": "Task",
               "Resource": "arn:aws:states:::aws-sdk:rds:stopDBCluster",
-              "Arguments": {
-                "DbClusterIdentifier": "{% $states.input.SourceIdentifier %}"
-              },
+              "Arguments": "{% {'DbClusterIdentifier': $states.input.SourceIdentifier} %}",
               "TimeoutSeconds": "{% $Constant.StepFnTaskTimeoutSeconds %}",
               "Catch": [
                 {
                   "ErrorEquals": [
                     "Rds.InvalidDbClusterStateException"
                   ],
-                  "Output": "{% (\n  $DbClusterStatusRegExpMatch := $match($states.errorOutput.Cause, /^DbCluster [^ ]+ is in (.+) state/, 1);\n  $merge([\n    $states.input,\n    $DbClusterStatusRegExpMatch\n    ?\n    {'DbStatus': $lowercase($DbClusterStatusRegExpMatch.groups[0])}\n    :\n    {'DbStatus': '', 'Error': 'StopDBCluster|CannotParseException', 'Cause': $string($states.errorOutput.Cause)}\n  ])\n) %}",
+                  "Output": "{% \n  $states.input\n  ~> |$|{'DbStatus': $lowercase($match($states.errorOutput.Cause, /^DbCluster [^ ]+ is in (.+) state/, 1).groups[0])}|\n  ~> |$|$.DbStatus ? {} : $states.errorOutput|\n  ~> |$|$.DbStatus ? {} : {'DbStatus': '', 'Error': $states.context.State.Name & '.' & $.Error & '.CannotParseException'}|\n %}",
                   "Next": "DbStatus"
                 },
                 {
@@ -743,7 +739,7 @@ Resources:
                     "States.ALL"
                   ],
                   "Comment": "Includes Rds.InvalidDbInstanceStateException, which occurs until each cluster member becomes available",
-                  "Output": "{% $merge([\n  $states.input,\n  {'Error': 'StopDBCluster|' & $states.errorOutput.Error, 'Cause': $string($states.errorOutput.Cause)}\n]) %}",
+                  "Output": "{% $states.input ~> |$|$states.errorOutput| ~> |$|{'Error': $states.context.State.Name & '.' & $.Error}| %}",
                   "Next": "Wait"
                 }
               ],
@@ -753,30 +749,29 @@ Resources:
             "StopDBInstance": {
               "Type": "Task",
               "Resource": "arn:aws:states:::aws-sdk:rds:stopDBInstance",
-              "Arguments": {
-                "DbInstanceIdentifier": "{% $states.input.SourceIdentifier %}"
-              },
+              "Arguments": "{% {'DbInstanceIdentifier': $states.input.SourceIdentifier} %}",
               "TimeoutSeconds": "{% $Constant.StepFnTaskTimeoutSeconds %}",
               "Catch": [
                 {
                   "ErrorEquals": [
                     "Rds.InvalidDbInstanceStateException"
                   ],
-                  "Output": "{% $merge([\n  $states.input,\n  {'Error': 'StopDBInstance|' & $states.errorOutput.Error, 'Cause': $string($states.errorOutput.Cause)}\n]) %}",
+                  "Output": "{% $states.input ~> |$|$states.errorOutput| ~> |$|{'Error': $states.context.State.Name & '.' & $.Error}| %}",
                   "Next": "DescribeDBInstances"
                 },
                 {
                   "ErrorEquals": [
                     "Rds.RdsException"
                   ],
-                  "Output": "{% $merge([\n  $states.input,\n  {'Error': 'StopDBInstance|' & $states.errorOutput.Error, 'Cause': $string($states.errorOutput.Cause)}\n]) %}",
+                  "Output": "{% $states.input ~> |$|$states.errorOutput| ~> |$|{'Error': $states.context.State.Name & '.' & $.Error}| %}",
+                  "Comment": "Next state uses Cause key of stashed errorOutput",
                   "Next": "AuroraDbInstanceNotEligibleForStopping?"
                 },
                 {
                   "ErrorEquals": [
                     "States.ALL"
                   ],
-                  "Output": "{% $merge([\n  $states.input,\n  {'Error': 'StopDBInstance|' & $states.errorOutput.Error, 'Cause': $string($states.errorOutput.Cause)}\n]) %}",
+                  "Output": "{% $states.input ~> |$|$states.errorOutput| ~> |$|{'Error': $states.context.State.Name & '.' & $.Error}| %}",
                   "Next": "Wait"
                 }
               ],
@@ -789,7 +784,7 @@ Resources:
                 {
                   "Condition": "{% $contains($states.input.Cause, 'aurora') and $contains($states.input.Cause, 'not eligible for stopping') %}",
                   "Comment": "Aurora: stop cluster, not instances. This InvalidParameterCombination occurs only in test mode. RDS-EVENT-0088 database instance non-forced start is indistinguishable for RDS (accepted) and Aurora (ignored in favor of RDS-EVENT-0151 for cluster).",
-                  "Output": "{% $merge([\n  $states.input,\n  {'Info': 'StopAuroraClusterNotInstances'}\n]) %}",
+                  "Output": "{% $states.input ~> |$|{'Info': 'StopAuroraClusterNotInstances'}| %}",
                   "Next": "Succeed"
                 }
               ],
@@ -798,20 +793,18 @@ Resources:
             "DescribeDBInstances": {
               "Type": "Task",
               "Resource": "arn:aws:states:::aws-sdk:rds:describeDBInstances",
-              "Arguments": {
-                "DbInstanceIdentifier": "{% $states.input.SourceIdentifier %}"
-              },
+              "Arguments": "{% {'DbInstanceIdentifier': $states.input.SourceIdentifier} %}",
               "TimeoutSeconds": "{% $Constant.StepFnTaskTimeoutSeconds %}",
               "Catch": [
                 {
                   "ErrorEquals": [
                     "States.ALL"
                   ],
-                  "Output": "{% $merge([\n  $states.input,\n{  'Error': 'DescribeDBInstances|' & $states.errorOutput.Error, 'Cause': $string($states.errorOutput.Cause)}\n]) %}",
+                  "Output": "{% $states.input ~> |$|$states.errorOutput| ~> |$|{'Error': $states.context.State.Name & '.' & $.Error}| %}",
                   "Next": "Wait"
                 }
               ],
-              "Output": "{% (\n  $DbInstanceStatus := $states.result.DbInstances[0].DbInstanceStatus;\n  $merge([\n    $states.input,\n    $DbInstanceStatus\n    ?\n    {'DbStatus': $lowercase($DbInstanceStatus)}\n    :\n    {'DbStatus': '', 'Error': 'DescribeDBInstances|CannotParseResult', 'Cause': $string($states.result)}\n  ])\n) %}",
+              "Output": "{% \n  $states.input\n  ~> |$|{'DbStatus': $lowercase($states.result.DbInstances[0].DbInstanceStatus)}|\n  ~> |$|$.DbStatus ? {} : {'DbStatus': '', 'Error': $states.context.State.Name & '.CannotParseResult', 'Cause': $string($states.result)}|\n %}",
               "Next": "DbStatus"
             },
             "DbStatus": {
@@ -819,7 +812,7 @@ Resources:
               "Choices": [
                 {
                   "Condition": "{% $states.input.DbStatus in ['inaccessible-encryption-credentials', 'cloning-failed', 'migration-failed', 'preparing-data-migration', 'failed', 'incompatible-restore', 'insufficient-capacity', 'restore-error', 'storage-full'] %}",
-                  "Output": "{% $merge([\n  $states.input,\n  {'Error': 'CannotContinueInDbStatus'}\n]) %}",
+                  "Output": "{% $states.input ~> |$|{'Error': $states.context.State.Name & '.CannotContinue'}| %}",
                   "Next": "Fail"
                 },
                 {
@@ -842,6 +835,8 @@ Resources:
             "Wait": {
               "Type": "Wait",
               "Seconds": "{% $Constant.StepFnWaitSeconds %}",
+              "Output": "{% $states.input ~> |$|{}, ['Error', 'Cause']| %}",
+              "Comment": "Deletes any past error",
               "Next": "IfEventNotExpiredChooseDbClusterOrInstance"
             },
             "Fail": {
@@ -849,7 +844,8 @@ Resources:
             },
             "Succeed": {
               "Type": "Succeed",
-              "Output": "{% \n  $states.input ~> | $ | {}, ['Error', 'Cause', 'DbStatus'] |\n  /* Delete any past error, and possibly-stale status; https://docs.jsonata.org/other-operators#-------transform */\n %}"
+              "Output": "{% $states.input ~> |$|{}, ['DbStatus', 'Error', 'Cause']| %}",
+              "Comment": "Deletes possibly-stale status, and any past error"
             }
           }
         }


### PR DESCRIPTION
- JSONata `~> |$|<merge_object>, <delete_key_array>|` replaces `$merge(<object_array>)`, for consistency and compactness

- Errors: `$states.errorOutput` is merged into Output, copying both the Error key and the Cause key

- Errors: prepend `$states.context.State.Name` instead of a literal string, when tracking the state where the most recent error occurred

- Errors: period (`.`) replaces vertical bar (`|`) as the delimiter, for consistency with Step Functions-AWS SDK integration `ErrorEquals` error names

- Previous 'Error', 'Cause' key deletion: moved from Choice state Condition rules (two identical occurrences) to Wait state (just one)

- Original event SourceType (`DB_INSTANCE` or `CLUSTER`): replaces SourceTypeWord (`INSTANCE` or `CLUSTER`) due to limited use (though much work would be saved and many bugs would be avoided if AWS event literals, API argument names, and response keys were all consistent!)

- CloudFormation `Fn::Sub` unquoted string to JSON Boolean value: more obvious handling, consistent with handling of numeric parameters

- `DbStatus` key: JSONata block with (`:=`) variable binding replaced with successive transforms, for a purely declarative approach (still want to provide empty string as a value, instead of undefined)

- Arguments objects: entire object in JSONata, in case multiple keys are added someday