### PR TITLE
DbStatus always present; empty string when unknown

### DIFF
--- a/step_stay_stopped_aws_rds_aurora.asl.json
+++ b/step_stay_stopped_aws_rds_aurora.asl.json
@@ -9,20 +9,21 @@
       "Assign": {
         "Constant": "{% {\n  'StepFnTaskTimeoutSeconds': ${StepFnTaskTimeoutSeconds},\n  'StepFnWaitSeconds': ${StepFnWaitSeconds},\n  'StepFnTimeoutMilliseconds': ${StepFnTimeoutSeconds} * 1000\n} %}"
       },
-      "Comment": "Process JSON state machine definition with CloudFormation Fn::Sub to resolve parameters, which are substituted as unquoted strings",
-      "Output": "{% {\n  'Event': $states.input,\n  'Date': $states.input.detail.Date,\n  'SourceIdentifier': $states.input.detail.SourceIdentifier,\n  'SourceType': $states.input.detail.SourceType\n} %}",
+      "Comment": "Process JSON state machine definition with CloudFormation Fn::Sub to resolve parameters",
+      "Output": "{% {\n  'Event': $states.input,\n  'Date': $states.input.detail.Date,\n  'SourceIdentifier': $states.input.detail.SourceIdentifier,\n  'SourceType': $states.input.detail.SourceType,\n  'DbStatus': ''\n} %}",
       "Next": "Wait"
     },
     "Wait": {
       "Type": "Wait",
       "Seconds": "{% $Constant.StepFnWaitSeconds %}",
-      "Output": "{% $states.input ~> |$|{}, ['DbStatus', 'Error', 'Cause']| %}",
-      "Comment": "Deletes possibly-stale status, and any past error",
+      "Output": "{% $states.input ~> |$|{'DbStatus': ''}, ['Error', 'Cause']| %}",
+      "Comment": "Clears possibly-stale status and deletes any past error",
       "Next": "IfEventNotExpiredChooseClusterOrInstance"
     },
     "IfEventNotExpiredChooseClusterOrInstance": {
       "Type": "Choice",
       "Choices": [
+
         {
           "Condition": "{% $toMillis($states.input.Date) < ($millis() - $Constant.StepFnTimeoutMilliseconds) %}",
           "Output": "{% $states.input ~> |$|{'Error': $states.context.State.Name & '.' & 'EventExpired'}| /* https://docs.jsonata.org/other-operators#-------transform */ %}",
@@ -48,7 +49,7 @@
           "ErrorEquals": [
             "Rds.InvalidDbClusterStateException"
           ],
-          "Output": "{% \n  $states.input\n  ~> |$|{'DbStatus': $lowercase($match($states.errorOutput.Cause, /^DbCluster [^ ]+ is in (.+) state/, 1).groups[0])}|\n  ~> |$|$.DbStatus ? {} : $states.errorOutput|\n  ~> |$|$.DbStatus ? {} : {'DbStatus': '', 'Error': $states.context.State.Name & '.' & $.Error & '.CannotParseException'}|\n %}",
+          "Output": "{% \n  $states.input\n  ~> |$|{'DbStatus': ''}|\n  ~> |$|{'DbStatus': $lowercase($match($states.errorOutput.Cause, /^DbCluster [^ ]+ is in (.+) state/, 1).groups[0])}|\n  ~> |$|$.DbStatus ? {} : $states.errorOutput|\n  ~> |$|$.DbStatus ? {} : {'Error': $states.context.State.Name & '.' & $.Error & '.CannotParseException'}|\n %}",
           "Next": "DbStatus"
         },
         {
@@ -109,7 +110,7 @@
           "Next": "Wait"
         }
       ],
-      "Output": "{% \n  $states.input\n  ~> |$|{'DbStatus': $lowercase($states.result.DbInstances[0].DbInstanceStatus)}|\n  ~> |$|$.DbStatus ? {} : {'DbStatus': '', 'Error': $states.context.State.Name & '.CannotParseResult', 'Cause': $string($states.result)}|\n %}",
+      "Output": "{% \n  $states.input\n  ~> |$|{'DbStatus': ''}|\n  ~> |$|{'DbStatus': $lowercase($states.result.DbInstances[0].DbInstanceStatus)}|\n  ~> |$|$.DbStatus ? {} : {'Error': $states.context.State.Name & '.CannotParseResult', 'Cause': $string($states.result)}|\n %}",
       "Next": "DbStatus"
     },
     "DbStatus": {
@@ -144,8 +145,8 @@
     },
     "Succeed": {
       "Type": "Succeed",
-      "Output": "{% $states.input ~> |$|{}, ['DbStatus', 'Error', 'Cause']| %}",
-      "Comment": "Deletes possibly-stale status, and any past error"
+      "Output": "{% $states.input ~> |$|{}, ['Error', 'Cause']| %}",
+      "Comment": "Deletes any past error"
     }
   }
 }

--- a/step_stay_stopped_aws_rds_aurora.yaml
+++ b/step_stay_stopped_aws_rds_aurora.yaml
@@ -690,6 +690,8 @@ Resources:
   StepFnLogGrp:
     Type: AWS::Logs::LogGroup
     Properties:
+      # https://docs.aws.amazon.com/step-functions/latest/dg/sfn-best-practices.html#bp-cwl
+      LogGroupName: !Sub "/aws/vendedlogs/states/${AWS::StackName}-StepFnLogGrp"
       RetentionInDays: !Ref LogRetentionInDays
       KmsKeyId:
         Fn::If:
@@ -738,20 +740,21 @@ Resources:
                 "Assign": {
                   "Constant": "{% {\n  'StepFnTaskTimeoutSeconds': ${StepFnTaskTimeoutSeconds},\n  'StepFnWaitSeconds': ${StepFnWaitSeconds},\n  'StepFnTimeoutMilliseconds': ${StepFnTimeoutSeconds} * 1000\n} %}"
                 },
-                "Comment": "Process JSON state machine definition with CloudFormation Fn::Sub to resolve parameters, which are substituted as unquoted strings",
-                "Output": "{% {\n  'Event': $states.input,\n  'Date': $states.input.detail.Date,\n  'SourceIdentifier': $states.input.detail.SourceIdentifier,\n  'SourceType': $states.input.detail.SourceType\n} %}",
+                "Comment": "Process JSON state machine definition with CloudFormation Fn::Sub to resolve parameters",
+                "Output": "{% {\n  'Event': $states.input,\n  'Date': $states.input.detail.Date,\n  'SourceIdentifier': $states.input.detail.SourceIdentifier,\n  'SourceType': $states.input.detail.SourceType,\n  'DbStatus': ''\n} %}",
                 "Next": "Wait"
               },
               "Wait": {
                 "Type": "Wait",
                 "Seconds": "{% $Constant.StepFnWaitSeconds %}",
-                "Output": "{% $states.input ~> |$|{}, ['DbStatus', 'Error', 'Cause']| %}",
-                "Comment": "Deletes possibly-stale status, and any past error",
+                "Output": "{% $states.input ~> |$|{'DbStatus': ''}, ['Error', 'Cause']| %}",
+                "Comment": "Clears possibly-stale status and deletes any past error",
                 "Next": "IfEventNotExpiredChooseClusterOrInstance"
               },
               "IfEventNotExpiredChooseClusterOrInstance": {
                 "Type": "Choice",
                 "Choices": [
+
                   {
                     "Condition": "{% $toMillis($states.input.Date) < ($millis() - $Constant.StepFnTimeoutMilliseconds) %}",
                     "Output": "{% $states.input ~> |$|{'Error': $states.context.State.Name & '.' & 'EventExpired'}| /* https://docs.jsonata.org/other-operators#-------transform */ %}",
@@ -777,7 +780,7 @@ Resources:
                     "ErrorEquals": [
                       "Rds.InvalidDbClusterStateException"
                     ],
-                    "Output": "{% \n  $states.input\n  ~> |$|{'DbStatus': $lowercase($match($states.errorOutput.Cause, /^DbCluster [^ ]+ is in (.+) state/, 1).groups[0])}|\n  ~> |$|$.DbStatus ? {} : $states.errorOutput|\n  ~> |$|$.DbStatus ? {} : {'DbStatus': '', 'Error': $states.context.State.Name & '.' & $.Error & '.CannotParseException'}|\n %}",
+                    "Output": "{% \n  $states.input\n  ~> |$|{'DbStatus': ''}|\n  ~> |$|{'DbStatus': $lowercase($match($states.errorOutput.Cause, /^DbCluster [^ ]+ is in (.+) state/, 1).groups[0])}|\n  ~> |$|$.DbStatus ? {} : $states.errorOutput|\n  ~> |$|$.DbStatus ? {} : {'Error': $states.context.State.Name & '.' & $.Error & '.CannotParseException'}|\n %}",
                     "Next": "DbStatus"
                   },
                   {
@@ -838,7 +841,7 @@ Resources:
                     "Next": "Wait"
                   }
                 ],
-                "Output": "{% \n  $states.input\n  ~> |$|{'DbStatus': $lowercase($states.result.DbInstances[0].DbInstanceStatus)}|\n  ~> |$|$.DbStatus ? {} : {'DbStatus': '', 'Error': $states.context.State.Name & '.CannotParseResult', 'Cause': $string($states.result)}|\n %}",
+                "Output": "{% \n  $states.input\n  ~> |$|{'DbStatus': ''}|\n  ~> |$|{'DbStatus': $lowercase($states.result.DbInstances[0].DbInstanceStatus)}|\n  ~> |$|$.DbStatus ? {} : {'Error': $states.context.State.Name & '.CannotParseResult', 'Cause': $string($states.result)}|\n %}",
                 "Next": "DbStatus"
               },
               "DbStatus": {
@@ -873,8 +876,8 @@ Resources:
               },
               "Succeed": {
                 "Type": "Succeed",
-                "Output": "{% $states.input ~> |$|{}, ['DbStatus', 'Error', 'Cause']| %}",
-                "Comment": "Deletes possibly-stale status, and any past error"
+                "Output": "{% $states.input ~> |$|{}, ['Error', 'Cause']| %}",
+                "Comment": "Deletes any past error"
               }
             }
           }


### PR DESCRIPTION
- Prefix CloudWatch log group name, based on a [Step Functions best practice that mitigates long CloudWatch Logs resource policies](https://docs.aws.amazon.com/step-functions/latest/dg/sfn-best-practices.html#bp-cwl).

- Pre-set `DBStatus` to the empty string so that failed `$match` calls and any errors will leave it that way.

  Three-valued, or in the case of JSONata, four-valued logics are bad! [try.jsonata.org](https://try.jsonata.org/)&nbsp;, given:

  ```jsonata
  {
    'not': {
      '$not(undefined)': $not(undefined),
      '$not(null)': $not(null),
      '$not(false)': $not(false),
      '$not(true)': $not(true)
    },
    'and': {
      'undefined and undefined': undefined and undefined,
      'undefined and null': undefined and null,
      'undefined and false': undefined and false,
      'undefined and true': undefined and true,
      'null and null': null and null,
      'null and false': null and false,
      'null and true': null and true
    },
    'or': {
      'undefined or undefined': undefined or undefined,
      'undefined or null': undefined or null,
      'undefined or false': undefined or false,
      'undefined or true': undefined or true,
      'null or null': null or null,
      'null or false': null or false,
      'null or true': null or true
    }
  }
  ```

  produces:

  ```json
  {
    "not": {
      "$not(null)": true,
      "$not(false)": true,
      "$not(true)": false
    },
    "and": {
      "undefined and undefined": false,
      "undefined and null": false,
      "undefined and false": false,
      "undefined and true": false,
      "null and null": false,
      "null and false": false,
      "null and true": false
    },
    "or": {
      "undefined or undefined": false,
      "undefined or null": false,
      "undefined or false": false,
      "undefined or true": true,
      "null or null": false,
      "null or false": false,
      "null or true": true
    }
  }
  ```

  There is no `undefined` in JSON, so in a [transform](https://docs.jsonata.org/other-operators#-------transform), a key set to `undefined` (or to `$match`, with a match that might fail) in the _update_ object disappears from that object, leaving an old value unchanged if the key was present in _head_._location_ . In other words,

  `{"sky": "blue"} ~> |$|{'sky': undefined}|` leaves `{"sky": "blue"}`

  An earlier update made sure stale `DbStatus` values were not being pushed around, by using a transform to delete `DbStatus`. Now, I set `DbStatus` to the empty string in those situations, to get crap like `undefined` and `null` out of my software.

  Three-valued logics can lead to obscure bugs, so I'm avoiding JSONata `undefined`.

  Returning to the truth tables above, a reasonable interpretation of `undefined` or of `null` in the context of a Boolean expression might be "don't know" or "don't care", meaning "might be true or false". If those interpretations were correct, `undefined and undefined` would be `undefined` instead of `false`, and `$not(null)` would be `null` instead of `true`. JSONata gives us a four-valued logic that doesn't make _sense_.

  Sure enough, there are multiple open issues that stem from confusion over null-type values, including:

  jsonata-js/jsonata#718

  jsonata-js/jsonata#740 (This one recalls old MySQL, the only world other than Dr. Seuss where null, zero, the empty set, the empty string, and the 0th day of the 0th month of the 0th year were all equal, and the date just mentioned was an allowable value.)

  See also the [Null (SQL) Wikipedia entry](https://en.wikipedia.org/wiki/Null_(SQL)#Comparisons_with_NULL_and_the_three-valued_logic_(3VL)).