### PR TITLE
ABAC exclusion and inclusion tags in Step Fn role

### DIFF
--- a/README.md
+++ b/README.md
@@ -382,7 +382,7 @@ entirely at your own risk. You are encouraged to review the source code.
 
 - A Step Function role that cannot be used by arbitrary functions. If the role
   is passed to an arbitrary Step Function, Task states will not gain access to
-  the AWS API.
+  the Aurora and RDS API.
 
 - A least-privilege queue policy. The error (dead letter) queue can only
   consume messages from EventBridge. Encryption in transit is required.
@@ -420,6 +420,14 @@ entirely at your own risk. You are encouraged to review the source code.
   production, or you might add a custom IAM policy to the function role,
   denying authority to stop certain production databases (`AttachLocalPolicy`
   in CloudFormation).
+
+  - Tagging an RDS database instance or an Aurora database cluster with
+    `StayStopped-Exclude` (see `ExcludeTagKey` in CloudFormation) prevents the
+    Step Function role from being misused to stop that database.
+    &#9888; Do not rely on
+    [attribute-based access control](https://docs.aws.amazon.com/IAM/latest/UserGuide/introduction_attribute-based-access-control.html)
+    unless you also prevent people and systems from adding, changing and
+    deleting ABAC tags.
 
 - Enable the test mode only in a non-critical AWS account and region, and turn
   the test mode off again as quickly as possible.

--- a/step_stay_stopped_aws_rds_aurora.yaml
+++ b/step_stay_stopped_aws_rds_aurora.yaml
@@ -47,6 +47,31 @@ Parameters:
     AllowedValues:
       - ""
 
+  ExcludeTagKey:
+    Type: String
+    Description: >-
+      An RDS database instance or Aurora database cluster with this tag will
+      not be stopped.
+      Specify only the tag key; tag values are ignored.
+      If ExcludeTagKey and IncludeTagKey are both blank, the Step Function role
+      has permission to stop any database (though the Step Function is only
+      triggered for databases that have already been stopped for 7 days).
+      The default is "StayStopped-Exclude".
+      For tag key rules, see
+      https://docs.aws.amazon.com/AmazonRDS/latest/UserGuide/USER_Tagging.html#Overview.Tagging.Structure
+    Default: "StayStopped-Exclude"
+
+  IncludeTagKey:
+    Type: String
+    Description: >-
+      An RDS database instance or Aurora database cluster without this tag will
+      not be stopped.
+      By default, this is blank and no database tag is required.
+      If a database has both the ExcludeTagKey and the IncludeTagKey, it will
+      not be stopped; exclusion wins.
+      See ExcludeTagKey for other important details.
+    Default: ""
+
   Test:
     Type: String
     Description: >-
@@ -223,6 +248,11 @@ Metadata:
         Parameters:
           - PlaceholderAdvancedParameters
       - Label:
+          default: Database tags
+        Parameters:
+          - ExcludeTagKey
+          - IncludeTagKey
+      - Label:
           default: Testing
         Parameters:
           - Test
@@ -258,6 +288,10 @@ Metadata:
         default: Follow the database after a stop request?
       PlaceholderAdvancedParameters:
         default: Do not change the parameters below, unless necessary!
+      ExcludeTagKey:
+        default: Do not stop an eligible database if it has this tag
+      IncludeTagKey:
+        default: Stop an eligible database only if it has this tag
       Test:
         default: Test mode?
       MessageRetentionPeriodSeconds:
@@ -290,6 +324,11 @@ Conditions:
   EnableTrue: !Equals [ !Ref Enable, "true" ]
 
   FollowUntilStoppedTrue: !Equals [ !Ref FollowUntilStopped, "true" ]
+
+  ExcludeTagKeySet: !Not [ !Equals [ !Ref ExcludeTagKey, "" ] ]
+  IncludeTagKeySet: !Not [ !Equals [ !Ref IncludeTagKey, "" ] ]
+  ExcludeTagKeySetOrIncludeTagKeySet:
+    !Or [ !Condition ExcludeTagKeySet, !Condition IncludeTagKeySet ]
 
   TestTrue: !Equals [ !Ref Test, "true" ]
 
@@ -430,10 +469,10 @@ Resources:
                   - !Sub "arn:${AWS::Partition}:rds:${AWS::Region}:${AWS::AccountId}:db:*"
                   - !Sub "arn:${AWS::Partition}:rds:${AWS::Region}:${AWS::AccountId}:cluster:*"
 
-        # JSON, so that an "aws:ResourceTag/tag-key" condition could be built
-        # up with substitutions, in the future. CloudFormation requires literal
-        # string keys, so !Sub "aws:ResourceTag/${TagKey}": "*" would give an
-        # "Unhashable type" error.
+        # JSON, because CloudFormation requires literal string keys.
+        # !Sub "aws:ResourceTag/${TagKey}": "*"
+        # would give an "Unhashable type" error.
+        # Empty "Condition": {} is OK.
         - PolicyName: RdsWrite
           PolicyDocument: !Sub
             - >-
@@ -448,10 +487,29 @@ Resources:
                   "Resource": [
                     "arn:${AWS::Partition}:rds:${AWS::Region}:${AWS::AccountId}:db:*",
                     "arn:${AWS::Partition}:rds:${AWS::Region}:${AWS::AccountId}:cluster:*"
-                  ]
+                  ],
+                  "Condition": {
+              ${TagConditions}
+                  }
                 }]
               }
-            - PlaceholderKeyForFutureUse: PlaceholderValueForFutureUse
+            - TagConditions: !Join
+                - |
+                  ,
+                - - !If
+                    - ExcludeTagKeySet
+                    - !Sub |-
+                        "StringNotLike": {
+                          "aws:ResourceTag/${ExcludeTagKey}": "*"
+                        }
+                    - !Ref AWS::NoValue
+                  - !If
+                    - IncludeTagKeySet
+                    - !Sub |-
+                        "StringLike": {
+                          "aws:ResourceTag/${IncludeTagKey}": "*"
+                        }
+                    - !Ref AWS::NoValue
 
         # https://docs.aws.amazon.com/step-functions/latest/dg/encryption-at-rest.html#encrypt-logs
         - Fn::If:
@@ -611,7 +669,7 @@ Resources:
             "source": [ "aws.rds" ],
             "detail": {
               "SourceIdentifier": [ { "anything-but": [ "" ] } ],
-              "Date": [ { "anything-but": [ "" ] } ]
+              "Date": [ { "anything-but": [ "" ] } ]${DetailTagsKey}
             },
             "$or": [
               {
@@ -630,13 +688,28 @@ Resources:
               }
             ]
           }
-        - AuroraTestEvent: !If
-            - TestTrue
-            - ', "RDS-EVENT-0151"'
-            - ""
-          RdsTestEvent: !If
-            - TestTrue
-            - ', "RDS-EVENT-0088"'
+        - AuroraTestEvent: !If [ TestTrue, ', "RDS-EVENT-0151"', "" ]
+          RdsTestEvent: !If [ TestTrue, ', "RDS-EVENT-0088"', "" ]
+          DetailTagsKey: !If
+            - ExcludeTagKeySetOrIncludeTagKeySet
+            - !Sub
+              - |-
+                  ,
+                  "Tags": {
+                    ${DetailTagsValue}
+                  }
+              - DetailTagsValue: !Join
+                  - ', '
+                  - - !If
+                      - ExcludeTagKeySet
+                      - !Sub |-
+                          "${ExcludeTagKey}": [ { "exists": false } ]
+                      - !Ref AWS::NoValue
+                    - !If
+                      - IncludeTagKeySet
+                      - !Sub |-
+                          "${IncludeTagKey}": [ { "exists": true } ]
+                      - !Ref AWS::NoValue
             - ""
       # Would prefer "anything-but": [ "", null ] . JSON EventPattern resolves:
       # https://github.com/aws-cloudformation/cloudformation-coverage-roadmap/issues/1378


### PR DESCRIPTION
- Event rule also makes use of tags, though to be clear, there is no need for tagging in this application. RDS-EVENT-0154 and RDS-EVENT-0153 are generated only for databases that have been stopped for 7 days, not for continuously-running databases.
- ABAC is not effective unless you also prevent people and systems from adding, changing and deleting critical tags.