### PR TITLE
terraform-multi : accept OU IDs instead of (top-level) OU names

### DIFF
--- a/README.md
+++ b/README.md
@@ -91,7 +91,7 @@ Other charges, such as for storage and snapshots, continue.
 
       ```terraform
       module "stay_stopped_rds" {
-        source = "git::https://github.com/sqlxpert/step-stay-stopped-aws-rds-aurora.git//terraform?ref=v2.3.0"
+        source = "git::https://github.com/sqlxpert/step-stay-stopped-aws-rds-aurora.git//terraform?ref=v2.3.1"
         # Reference a specific version from github.com/sqlxpert/step-stay-stopped-aws-rds-aurora/releases
       }
       ```
@@ -157,21 +157,18 @@ AWS account. To deploy in multiple regions and/or multiple AWS accounts,
 
       ```terraform
       module "stay_stopped_rds_stackset" {
-        source = "git::https://github.com/sqlxpert/step-stay-stopped-aws-rds-aurora.git//terraform-multi?ref=v2.3.0"
+        source = "git::https://github.com/sqlxpert/step-stay-stopped-aws-rds-aurora.git//terraform-multi?ref=v2.3.1"
         # Reference a specific version from github.com/sqlxpert/step-stay-stopped-aws-rds-aurora/releases
 
-        stay_stopped_rds_stackset_regions = ["us-east-1", "us-west-2", ]
-        stay_stopped_rds_stackset_organizational_unit_names = [
-          "MyOrganizationalUnit",
+        stay_stopped_rds_stackset_regions = ["us-east-1", "us-west-2",]
+        stay_stopped_rds_stackset_organizational_unit_ids = [
+          "ou-0123-abcdefg",
         ]
       }
       ```
 
       Test mode is always disabled in this configuration. This is a safeguard
       against unintended use in production.
-
-      &#9888; **In Terraform, specify the name(s) of the target organization
-      unit(s)**, not the `ou-` ID(s).
 
 ## Installation with Terraform
 
@@ -194,10 +191,10 @@ resemble:
 
 ```terraform
 module "stay_stopped_rds" {
-  source = "git::https://github.com/sqlxpert/step-stay-stopped-aws-rds-aurora.git//terraform?ref=v2.3.0"
+  source = "git::https://github.com/sqlxpert/step-stay-stopped-aws-rds-aurora.git//terraform?ref=v2.3.1"
   # Reference a specific version from github.com/sqlxpert/step-stay-stopped-aws-rds-aurora/releases
 
-  for_each                = toset(["us-east-1", "us-west-2", ])
+  for_each                = toset(["us-east-1", "us-west-2",])
   stay_stopped_rds_region = each.key
 }
 ```

--- a/terraform-multi/main.tf
+++ b/terraform-multi/main.tf
@@ -13,6 +13,7 @@ data "aws_region" "stay_stopped_rds_stackset" {
 }
 
 
+
 # Remove when stay_stopped_rds_stackset_organizational_unit_names is removed.
 data "aws_organizations_organization" "current" {}
 data "aws_organizations_organizational_unit" "stay_stopped_rds_stackset" {

--- a/terraform-multi/main.tf
+++ b/terraform-multi/main.tf
@@ -13,7 +13,7 @@ data "aws_region" "stay_stopped_rds_stackset" {
 }
 
 
-
+# Remove when stay_stopped_rds_stackset_organizational_unit_names is removed.
 data "aws_organizations_organization" "current" {}
 data "aws_organizations_organizational_unit" "stay_stopped_rds_stackset" {
   for_each = toset(
@@ -23,6 +23,13 @@ data "aws_organizations_organizational_unit" "stay_stopped_rds_stackset" {
   parent_id = data.aws_organizations_organization.current.roots[0].id
   name      = each.key
 }
+# This data source, by its pair of required arguments, must call
+# organizations:ListOrganizationalUnitsForParent . Sure enough,
+# https://github.com/hashicorp/terraform-provider-aws/blob/5c9e51b/internal/service/organizations/organizational_unit_data_source.go#L52
+# To check the existence of arbitrary OUs before passing them to
+# CloudFormation, with only OU IDs to go on, we'd need a data source that calls
+# DescribeOrganizationalUnit , but there is no such data source as of 2026-03.
+# https://github.com/search?q=repo%3Ahashicorp%2Fterraform-provider-aws+DescribeOrganizationalUnit&type=code
 
 
 
@@ -90,11 +97,13 @@ resource "aws_cloudformation_stack_set_instance" "stay_stopped_rds" {
 
   stack_set_instance_region = each.value.region
   deployment_targets {
-    organizational_unit_ids = sort([
+    organizational_unit_ids = sort(toset(concat([
       for organizational_unit_key, organizational_unit
       in data.aws_organizations_organizational_unit.stay_stopped_rds_stackset
       : organizational_unit.id
-    ])
+      ],
+      var.stay_stopped_rds_stackset_organizational_unit_ids,
+    )))
   }
   retain_stack = false
 

--- a/terraform-multi/variables.tf
+++ b/terraform-multi/variables.tf
@@ -119,14 +119,26 @@ variable "stay_stopped_rds_tags" {
 
 variable "stay_stopped_rds_stackset_organizational_unit_names" {
   type        = list(string)
-  description = "List of the names (not the IDs) of the organizational units in which to create instances of the CloudFormation StackSet. At least one is required. The organizational units must exist. Within a region, deployments will always proceed in alphabetical order by OU ID (not by name)."
+  description = "List of the names (not the IDs) of the organizational units in which to create instances of the CloudFormation StackSet. At least one is required. The organizational units must exist. Within a region, deployments will always proceed in alphabetical order by OU ID (not by name). Deprecated. Start with, or switch to, stay_stopped_rds_stackset_organizational_unit_ids ."
+
+  default = []
+}
+
+variable "stay_stopped_rds_stackset_organizational_unit_ids" {
+  type        = list(string)
+  description = "List of the IDs of the organizational units in which to create instances of the CloudFormation StackSet. At least one OU must be specified. Within a region, deployments will always proceed in alphabetical order by OU ID."
+
+  default = []
+  # Until stay_stopped_rds_stackset_organizational_unit_names is removed
 
   validation {
-    error_message = "At least one organizational unit name is required."
+    error_message = "At least one organizational unit ID is required."
 
-    condition = length(
-      var.stay_stopped_rds_stackset_organizational_unit_names
-    ) >= 1
+    condition = (length(
+      var.stay_stopped_rds_stackset_organizational_unit_ids
+      ) >= 1) || (
+      length(var.stay_stopped_rds_stackset_organizational_unit_names) >= 1
+    )
   }
 }
 


### PR DESCRIPTION
Originally, I wanted to check the existence of OUs before passing control to CloudFormation. Access to data sources for input validation is an advantage of using Terraform. In CloudFormation, one would have to define a custom resource and write a Lambda function! Terraform AWS provider data source limitations (documented in a new comment) led me to accept OU _names_ instead of IDs. Because OU names are unique only immediately below a given parent OU, my original implementation accepted top-level OUs only.

By accepting OU _IDs_, I'm giving up early checking but allowing deployment to OUs at any level of an organization's hierarchy.

The unusual line break choices make...

- current changes needed to support OU IDs in addition to OU names
- future changes needed to remove support for OU names

...easy to see in GitHub diffs.